### PR TITLE
Handle another input format for ReadNElements function

### DIFF
--- a/pythonXdmfReader.py
+++ b/pythonXdmfReader.py
@@ -154,7 +154,12 @@ def ReadNElements(xdmfFilename):
    tree = ET.parse(xdmfFilename)
    root = tree.getroot()
    for Property in root.findall('Domain/Grid/Grid/Topology'):
-      return int(Property.get("NumberOfElements"))
+      path = Property.get("Reference")
+      if path is None:
+         return int(Property.get("NumberOfElements"))
+      else:
+         ref = tree.xpath(path)[0]
+         return int(ref.get("NumberOfElements"))
    raise NameError('nElements could not be determined')
 
 def ReadTimeStep(xdmfFilename):


### PR DESCRIPTION
Handle the case when the data file name is in a referenced element, just like the PR #1, but this time for the `ReadNElements` function.
You can use the example I sent you via email with `ComputeGroundMotionsEstimatesFromSurfaceMPI.py`, there is a `ReadNElements` call in this module.